### PR TITLE
Add lazy loading to gallery and credits images

### DIFF
--- a/credits.html
+++ b/credits.html
@@ -44,12 +44,17 @@
         <div class="credit-item">
           Made with
           <div id="logos" style="margin-top: 5px">
-            <img class="logo-img" src="assets/images/blender_white.png" />
+            <img
+              class="logo-img"
+              src="assets/images/blender_white.png"
+              loading="lazy"
+            />
           </div>
           <div id="logos" style="margin-top: 10px">
             <img
               class="logo-img"
               src="assets/images/UE-Logotype-2023-SplashScreen-Vertical-White.png"
+              loading="lazy"
             />
           </div>
         </div>

--- a/gallery.html
+++ b/gallery.html
@@ -17,25 +17,97 @@
       </div>
       <div id="gradient"></div>
       <div class="gallery-box">
-        <img class="gallery-img" src="assets/images/gallery/ministeri.png" />
-        <img class="gallery-img" src="assets/images/gallery/portaMinisteri.png" />
-        <img class="gallery-img" src="assets/images/gallery/corridoio.png" />
-        <img class="gallery-img" src="assets/images/gallery/scale2.png" />
-        <img class="gallery-img" src="assets/images/gallery/sotterraneo2.png" />
-        <img class="gallery-img" src="assets/images/gallery/Winston.png" />
-        <img class="gallery-img" src="assets/images/gallery/room101Side.png" />
-        <img class="gallery-img" src="assets/images/gallery/camera.png" />
+        <img
+          class="gallery-img"
+          src="assets/images/gallery/ministeri.png"
+          loading="lazy"
+        />
+        <img
+          class="gallery-img"
+          src="assets/images/gallery/portaMinisteri.png"
+          loading="lazy"
+        />
+        <img
+          class="gallery-img"
+          src="assets/images/gallery/corridoio.png"
+          loading="lazy"
+        />
+        <img
+          class="gallery-img"
+          src="assets/images/gallery/scale2.png"
+          loading="lazy"
+        />
+        <img
+          class="gallery-img"
+          src="assets/images/gallery/sotterraneo2.png"
+          loading="lazy"
+        />
+        <img
+          class="gallery-img"
+          src="assets/images/gallery/Winston.png"
+          loading="lazy"
+        />
+        <img
+          class="gallery-img"
+          src="assets/images/gallery/room101Side.png"
+          loading="lazy"
+        />
+        <img
+          class="gallery-img"
+          src="assets/images/gallery/camera.png"
+          loading="lazy"
+        />
 
-        <img class="gallery-img" src="assets/images/gallery/room101Porta.png" />
-        <img class="gallery-img" src="assets/images/gallery/julia1.png" />
-        <img class="gallery-img" src="assets/images/gallery/psicopolMaster.png" />
-        <img class="gallery-img" src="assets/images/gallery/psicopolClose.png" />
-        <img class="gallery-img" src="assets/images/gallery/piazza.png" />
-        <img class="gallery-img" src="assets/images/gallery/casaWinston.png" />
-        <img class="gallery-img" src="assets/images/gallery/occhioPiange.png" />
-        <img class="gallery-img" src="assets/images/gallery/julia3.png" />
-        <img class="gallery-img" src="assets/images/gallery/juliaMangiata1.png" />
-        <img class="gallery-img" src="assets/images/gallery/juliaMangiata4.png" />
+        <img
+          class="gallery-img"
+          src="assets/images/gallery/room101Porta.png"
+          loading="lazy"
+        />
+        <img
+          class="gallery-img"
+          src="assets/images/gallery/julia1.png"
+          loading="lazy"
+        />
+        <img
+          class="gallery-img"
+          src="assets/images/gallery/psicopolMaster.png"
+          loading="lazy"
+        />
+        <img
+          class="gallery-img"
+          src="assets/images/gallery/psicopolClose.png"
+          loading="lazy"
+        />
+        <img
+          class="gallery-img"
+          src="assets/images/gallery/piazza.png"
+          loading="lazy"
+        />
+        <img
+          class="gallery-img"
+          src="assets/images/gallery/casaWinston.png"
+          loading="lazy"
+        />
+        <img
+          class="gallery-img"
+          src="assets/images/gallery/occhioPiange.png"
+          loading="lazy"
+        />
+        <img
+          class="gallery-img"
+          src="assets/images/gallery/julia3.png"
+          loading="lazy"
+        />
+        <img
+          class="gallery-img"
+          src="assets/images/gallery/juliaMangiata1.png"
+          loading="lazy"
+        />
+        <img
+          class="gallery-img"
+          src="assets/images/gallery/juliaMangiata4.png"
+          loading="lazy"
+        />
       </div>
     </div>
 

--- a/process.html
+++ b/process.html
@@ -28,20 +28,52 @@
         <section id="sketches" class="proc-section">
           <h2>SKETCHES</h2>
           <div class="proc-row">
-            <img class="gallery-img proc half" src="assets/images/process/proc-ministero.jpg" />
-            <img class="gallery-img proc half" src="assets/images/process/proc-piazza.jpg" />
+              <img
+                class="gallery-img proc half"
+                src="assets/images/process/proc-ministero.jpg"
+                loading="lazy"
+              />
+              <img
+                class="gallery-img proc half"
+                src="assets/images/process/proc-piazza.jpg"
+                loading="lazy"
+              />
           </div>
           <div class="proc-row">
-            <img class="gallery-img proc half" src="assets/images/process/proc-logos-1.jpg" />
-            <img class="gallery-img proc half" src="assets/images/process/proc-logos-2.jpg" />
+              <img
+                class="gallery-img proc half"
+                src="assets/images/process/proc-logos-1.jpg"
+                loading="lazy"
+              />
+              <img
+                class="gallery-img proc half"
+                src="assets/images/process/proc-logos-2.jpg"
+                loading="lazy"
+              />
           </div>
           <div class="proc-row">
-            <img class="gallery-img proc half" src="assets/images/process/proc-psicopol-1.jpg" />
-            <img class="gallery-img proc half" src="assets/images/process/proc-psicopol-2.jpg" />
+              <img
+                class="gallery-img proc half"
+                src="assets/images/process/proc-psicopol-1.jpg"
+                loading="lazy"
+              />
+              <img
+                class="gallery-img proc half"
+                src="assets/images/process/proc-psicopol-2.jpg"
+                loading="lazy"
+              />
           </div>
           <div class="proc-row">
-            <img class="gallery-img proc half" src="assets/images/process/proc-room.jpg" />
-            <img class="gallery-img proc half" src="assets/images/process/proc-gabbia.jpg" />
+              <img
+                class="gallery-img proc half"
+                src="assets/images/process/proc-room.jpg"
+                loading="lazy"
+              />
+              <img
+                class="gallery-img proc half"
+                src="assets/images/process/proc-gabbia.jpg"
+                loading="lazy"
+              />
           </div>
         </section>
         <section id="moodboard" class="proc-section">
@@ -59,7 +91,11 @@
         <section id="storyboard" class="proc-section">
           <h2>STORYBOARD</h2>
           <div class="proc-row">
-            <img class="gallery-img proc" src="assets/images/process/storyboard.jpg" />
+              <img
+                class="gallery-img proc"
+                src="assets/images/process/storyboard.jpg"
+                loading="lazy"
+              />
           </div>
         </section>
         <section id="environments" class="proc-section">
@@ -144,7 +180,11 @@
         </section>
         <section id="props" class="proc-section">
           <h2>PROPS</h2>
-          <img class="gallery-img proc" src="assets/images/gallery/piazza.png" />
+            <img
+              class="gallery-img proc"
+              src="assets/images/gallery/piazza.png"
+              loading="lazy"
+            />
         </section>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- enable native lazy loading on gallery images
- defer loading for process page images
- lazily load logo images on credits page

## Testing
- `npm test` *(fails: could not read package.json)*
- `pip install playwright` *(fails: Could not find a version that satisfies the requirement playwright)*
- `rg --pcre2 --multiline '<img(?![^>]*loading="lazy")[^>]*>' 101`

------
https://chatgpt.com/codex/tasks/task_e_6898a686cd48832c913473fb800e14ce