### PR TITLE
Add explicit image dimensions

### DIFF
--- a/credits.html
+++ b/credits.html
@@ -44,12 +44,14 @@
         <div class="credit-item">
           Made with
           <div id="logos" style="margin-top: 5px">
-            <img class="logo-img" src="assets/images/blender_white.png" />
+            <img class="logo-img" src="assets/images/blender_white.png" width="2048" height="550" />
           </div>
           <div id="logos" style="margin-top: 10px">
             <img
               class="logo-img"
               src="assets/images/UE-Logotype-2023-SplashScreen-Vertical-White.png"
+              width="2372"
+              height="2880"
             />
           </div>
         </div>

--- a/gallery.html
+++ b/gallery.html
@@ -17,31 +17,31 @@
       </div>
       <div id="gradient"></div>
       <div class="gallery-box">
-        <img class="gallery-img" src="assets/images/gallery/ministeri.png" />
-        <img class="gallery-img" src="assets/images/gallery/portaMinisteri.png" />
-        <img class="gallery-img" src="assets/images/gallery/corridoio.png" />
-        <img class="gallery-img" src="assets/images/gallery/scale2.png" />
-        <img class="gallery-img" src="assets/images/gallery/sotterraneo2.png" />
-        <img class="gallery-img" src="assets/images/gallery/Winston.png" />
-        <img class="gallery-img" src="assets/images/gallery/room101Side.png" />
-        <img class="gallery-img" src="assets/images/gallery/camera.png" />
+        <img class="gallery-img" src="assets/images/gallery/ministeri.png" width="1440" height="1080" />
+        <img class="gallery-img" src="assets/images/gallery/portaMinisteri.png" width="1440" height="1080" />
+        <img class="gallery-img" src="assets/images/gallery/corridoio.png" width="1440" height="1080" />
+        <img class="gallery-img" src="assets/images/gallery/scale2.png" width="1440" height="1080" />
+        <img class="gallery-img" src="assets/images/gallery/sotterraneo2.png" width="1440" height="1080" />
+        <img class="gallery-img" src="assets/images/gallery/Winston.png" width="1440" height="1080" />
+        <img class="gallery-img" src="assets/images/gallery/room101Side.png" width="1440" height="1080" />
+        <img class="gallery-img" src="assets/images/gallery/camera.png" width="1440" height="1080" />
 
-        <img class="gallery-img" src="assets/images/gallery/room101Porta.png" />
-        <img class="gallery-img" src="assets/images/gallery/julia1.png" />
-        <img class="gallery-img" src="assets/images/gallery/psicopolMaster.png" />
-        <img class="gallery-img" src="assets/images/gallery/psicopolClose.png" />
-        <img class="gallery-img" src="assets/images/gallery/piazza.png" />
-        <img class="gallery-img" src="assets/images/gallery/casaWinston.png" />
-        <img class="gallery-img" src="assets/images/gallery/occhioPiange.png" />
-        <img class="gallery-img" src="assets/images/gallery/julia3.png" />
-        <img class="gallery-img" src="assets/images/gallery/juliaMangiata1.png" />
-        <img class="gallery-img" src="assets/images/gallery/juliaMangiata4.png" />
+        <img class="gallery-img" src="assets/images/gallery/room101Porta.png" width="1440" height="1080" />
+        <img class="gallery-img" src="assets/images/gallery/julia1.png" width="1440" height="1080" />
+        <img class="gallery-img" src="assets/images/gallery/psicopolMaster.png" width="1440" height="1080" />
+        <img class="gallery-img" src="assets/images/gallery/psicopolClose.png" width="1440" height="1080" />
+        <img class="gallery-img" src="assets/images/gallery/piazza.png" width="1440" height="1080" />
+        <img class="gallery-img" src="assets/images/gallery/casaWinston.png" width="1440" height="1080" />
+        <img class="gallery-img" src="assets/images/gallery/occhioPiange.png" width="1440" height="1080" />
+        <img class="gallery-img" src="assets/images/gallery/julia3.png" width="1440" height="1080" />
+        <img class="gallery-img" src="assets/images/gallery/juliaMangiata1.png" width="1440" height="1080" />
+        <img class="gallery-img" src="assets/images/gallery/juliaMangiata4.png" width="1440" height="1080" />
       </div>
     </div>
 
     <!-- Enlarged image display -->
     <div id="enlarged-image-container">
-      <img id="enlarged-image" src="" alt="Enlarged Image" />
+      <img id="enlarged-image" src="" alt="Enlarged Image" width="1440" height="1080" />
     </div>
 
     <script src="script_gallery.js"></script>

--- a/process.html
+++ b/process.html
@@ -28,20 +28,20 @@
         <section id="sketches" class="proc-section">
           <h2>SKETCHES</h2>
           <div class="proc-row">
-            <img class="gallery-img proc half" src="assets/images/process/proc-ministero.jpg" />
-            <img class="gallery-img proc half" src="assets/images/process/proc-piazza.jpg" />
+            <img class="gallery-img proc half" src="assets/images/process/proc-ministero.jpg" width="1600" height="2000" />
+            <img class="gallery-img proc half" src="assets/images/process/proc-piazza.jpg" width="1600" height="2000" />
           </div>
           <div class="proc-row">
-            <img class="gallery-img proc half" src="assets/images/process/proc-logos-1.jpg" />
-            <img class="gallery-img proc half" src="assets/images/process/proc-logos-2.jpg" />
+            <img class="gallery-img proc half" src="assets/images/process/proc-logos-1.jpg" width="1600" height="2000" />
+            <img class="gallery-img proc half" src="assets/images/process/proc-logos-2.jpg" width="1600" height="2000" />
           </div>
           <div class="proc-row">
-            <img class="gallery-img proc half" src="assets/images/process/proc-psicopol-1.jpg" />
-            <img class="gallery-img proc half" src="assets/images/process/proc-psicopol-2.jpg" />
+            <img class="gallery-img proc half" src="assets/images/process/proc-psicopol-1.jpg" width="1600" height="2000" />
+            <img class="gallery-img proc half" src="assets/images/process/proc-psicopol-2.jpg" width="1600" height="2000" />
           </div>
           <div class="proc-row">
-            <img class="gallery-img proc half" src="assets/images/process/proc-room.jpg" />
-            <img class="gallery-img proc half" src="assets/images/process/proc-gabbia.jpg" />
+            <img class="gallery-img proc half" src="assets/images/process/proc-room.jpg" width="1600" height="2000" />
+            <img class="gallery-img proc half" src="assets/images/process/proc-gabbia.jpg" width="1600" height="2000" />
           </div>
         </section>
         <section id="moodboard" class="proc-section">
@@ -59,7 +59,7 @@
         <section id="storyboard" class="proc-section">
           <h2>STORYBOARD</h2>
           <div class="proc-row">
-            <img class="gallery-img proc" src="assets/images/process/storyboard.jpg" />
+            <img class="gallery-img proc" src="assets/images/process/storyboard.jpg" width="3000" height="2000" />
           </div>
         </section>
         <section id="environments" class="proc-section">
@@ -144,7 +144,7 @@
         </section>
         <section id="props" class="proc-section">
           <h2>PROPS</h2>
-          <img class="gallery-img proc" src="assets/images/gallery/piazza.png" />
+          <img class="gallery-img proc" src="assets/images/gallery/piazza.png" width="1440" height="1080" />
         </section>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Set fixed width and height on gallery images to match source assets
- Annotate process images and storyboard with their pixel dimensions
- Include dimensions for Blender and Unreal Engine logos in credits

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898bcc169b4832c8a9e0de1ef73ad59